### PR TITLE
Update concat_vl.py

### DIFF
--- a/models/concat_vl.py
+++ b/models/concat_vl.py
@@ -35,7 +35,7 @@ class LanguageAndVisionConcat(BaseModel):
             self.vision_module(image)
         )
         combined = torch.cat(
-            [text_features, image_features.squeeze()], dim=1
+            [text_features, image_features.squeeze(dim=1)], dim=1
         )
         fused = self.dropout(
             torch.nn.functional.relu(


### PR DESCRIPTION
Squeeze image_features to correct dimension mismatch RuntimeError "Tensors must have same number of dimensions" while training.